### PR TITLE
potter: add config_canForceDisableNavigationBar to overlay

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -534,4 +534,8 @@
 
     <!-- Whether the device supports Smart Pixels -->
     <bool name="config_supportSmartPixels">true</bool>
+
+    <!-- Whether device can force navbar disabling -->
+    <bool name="config_canForceDisableNavigationBar">true</bool>
+
 </resources>


### PR DESCRIPTION
*For enabling/disabling nav bar

Signed-off-by: ZJRDroid <github@zjrdroid.tech>